### PR TITLE
Fix TypeScript warnings about 'this' type in generateTexture method

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -47,6 +47,7 @@ function create() {
 
 	// Generate a Phaser texture given width, height, and color
 	function generateTexture(
+		this: Phaser.Scene,
 		name: string,
 		width: number,
 		height: number,


### PR DESCRIPTION
Related to #29

Add type annotation to generateTexture

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/abrie/nl5/issues/29?shareId=92282531-fa2e-4319-b282-b1ff76f6fc50).