### PR TITLE
Fix Typescript warnings about Properties 'player' and 'cursors'

### DIFF
--- a/src/MainScene.ts
+++ b/src/MainScene.ts
@@ -2,8 +2,9 @@ import { Scene } from "phaser";
 import { MapGenerator } from "./MapGenerator";
 
 class MainScene extends Scene {
-  private player: Phaser.Types.Physics.Arcade.SpriteWithDynamicBody;
-  private cursors: Phaser.Types.Input.Keyboard.CursorKeys;
+  // Use definite assignment assertions for player and cursors properties
+  private player!: Phaser.Types.Physics.Arcade.SpriteWithDynamicBody;
+  private cursors!: Phaser.Types.Input.Keyboard.CursorKeys;
 
   constructor() {
     super({ key: "MainScene" });


### PR DESCRIPTION
Related to #33

Use typescript definate assignments

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/abrie/nl5/issues/33?shareId=1768fd0f-7da0-46f7-aea8-d62dc1f2070c).