### PR TITLE
Fix drawing of the grappling hook

### DIFF
--- a/src/MainScene.ts
+++ b/src/MainScene.ts
@@ -131,7 +131,6 @@ class MainScene extends Scene {
 		if (this.input.keyboard.addKey(Phaser.Input.Keyboard.KeyCodes.SHIFT).isDown) {
 			if (!this.grapplingHookDeployed) {
 				this.grapplingHookDeployed = true;
-				this.drawGrapplingHook();
 			}
 		} else {
 			if (this.grapplingHookDeployed) {
@@ -151,6 +150,7 @@ class MainScene extends Scene {
 			}
 			this.player.setVelocityX(0); // Set horizontal velocity to zero
 			this.player.body.acceleration.x = 0; // Set horizontal acceleration to zero
+			this.drawGrapplingHook();
 		}
 	}
 


### PR DESCRIPTION
Related to #48

Update the grappling hook drawing logic to follow the player's position continuously.

* Modify `src/MainScene.ts` to call `drawGrapplingHook` within the `update` method when the grappling hook is deployed.
* Remove the call to `drawGrapplingHook` from the grappling hook deployment logic.
* Ensure the grappling hook's origin is updated continuously to follow the player's position.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/abrie/nl5/issues/48?shareId=26190bb0-fc7c-48ca-8e40-891f222ee14f).