### PR TITLE
Fix TypeScript warning in MainScene

### DIFF
--- a/src/MainScene.ts
+++ b/src/MainScene.ts
@@ -205,10 +205,10 @@ class MainScene extends Scene {
 	}
 
 	private collectLoot(
-		player: Phaser.Types.Physics.Arcade.SpriteWithDynamicBody,
-		lootItem: Phaser.Physics.Arcade.Sprite,
+		player: Phaser.GameObjects.GameObject,
+		lootItem: Phaser.GameObjects.GameObject,
 	) {
-		lootItem.destroy();
+		(lootItem as Phaser.Physics.Arcade.Sprite).destroy();
 		// Add loot to player's inventory (to be implemented)
 	}
 


### PR DESCRIPTION
Related to #50

Update the `collectLoot` method signature to match the expected types in the `this.physics.add.overlap` function.

* Change the `collectLoot` method parameters to use `Phaser.GameObjects.GameObject` for `player` and `lootItem`.
* Cast `lootItem` to `Phaser.Physics.Arcade.Sprite` before calling `destroy()`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/abrie/nl5/issues/50?shareId=9cb5c7c7-8709-465b-9bef-62fdfe6dea9b).