### PR TITLE
Fix map regeneration obscuring player and grappling hook

### DIFF
--- a/src/MainScene.ts
+++ b/src/MainScene.ts
@@ -169,7 +169,10 @@ class MainScene extends Scene {
 			callback: this.regenerateMap,
 			callbackScope: this,
 			loop: true,
-		});
+			});
+
+		// Bring the player sprite to the front
+		this.bringPlayerToFront();
 	}
 
 	update() {
@@ -370,7 +373,14 @@ class MainScene extends Scene {
 			0,
 			this.map.widthInPixels,
 			this.map.heightInPixels,
-		);
+			);
+
+		// Bring the player sprite to the front
+		this.bringPlayerToFront();
+	}
+
+	private bringPlayerToFront() {
+		this.children.bringToTop(this.player);
 	}
 }
 


### PR DESCRIPTION
Related to #64

Ensure the player sprite remains visible during map regeneration.

* Add a new method `bringPlayerToFront` to bring the player sprite to the front of the scene.
* Call `bringPlayerToFront` method at the end of the `regenerateMap` method.
* Call `bringPlayerToFront` method at the end of the `create` method.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/abrie/nl5/issues/64?shareId=86ad5ad5-0121-4f06-9c7f-403551f38c21).