### PR TITLE
Fix grappling hook visibility after map regeneration

### DIFF
--- a/src/MainScene.ts
+++ b/src/MainScene.ts
@@ -386,10 +386,17 @@ class MainScene extends Scene {
 
 		// Bring the player sprite to the front
 		this.bringPlayerToFront();
+
+		// Bring the grappling hook graphics object to the front
+		this.bringGrapplingHookToFront();
 	}
 
 	private bringPlayerToFront() {
 		this.children.bringToTop(this.player);
+	}
+
+	private bringGrapplingHookToFront() {
+		this.children.bringToTop(this.grapplingHookLine);
 	}
 }
 


### PR DESCRIPTION
Related to #68

Add logic to bring the grappling hook graphics object to the front after the map is regenerated.

* Add `bringGrapplingHookToFront` method to bring the grappling hook graphics object to the front.
* Call `bringGrapplingHookToFront` method in the `regenerateMap` method to ensure the grappling hook graphics object is not obscured.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/abrie/nl5/issues/68?shareId=bf7ad1fe-8986-4959-825b-971b31cdb974).