### PR TITLE
Use getTileAt and putTileAt to update the wall layer during map regeneration

### DIFF
--- a/src/MainScene.ts
+++ b/src/MainScene.ts
@@ -1,5 +1,6 @@
 import { Scene, Input } from "phaser";
 import { MapGenerator } from "./MapGenerator";
+import { getTileAt, putTileAt } from "phaser";
 
 const Config = {
 	TileSize: 16,
@@ -307,7 +308,17 @@ class MainScene extends Scene {
 			Config.MapWidth,
 			Config.MapHeight,
 			wallThickness,
-		);
+			);
+
+		const layer = this.map.getLayer(0).tilemapLayer;
+		for (let row = 0; row < map.length; row++) {
+			for (let col = 0; col < map[row].length; col++) {
+				const tile = getTileAt(layer, col, row);
+				if (tile) {
+					putTileAt(map[row][col], col, row, layer);
+				}
+			}
+		}
 	}
 }
 

--- a/src/MapGenerator.ts
+++ b/src/MapGenerator.ts
@@ -109,6 +109,17 @@ class MapGenerator {
 
 		return false;
 	}
+
+	generatePlayableMap(
+		mapWidth: number,
+		mapHeight: number,
+		wallThickness: number = 0,
+	): number[][] {
+		let map: number[][] = Array.from({ length: mapHeight }, () =>
+			Array(mapWidth).fill(0),
+		);
+		return this.generateMap(map, wallThickness, mapWidth, mapHeight);
+	}
 }
 
-export { MapGenerator };
+export { MapGenerator, generatePlayableMap };


### PR DESCRIPTION
Related to #70

Update `regenerateMap` to use `getTileAt` and `putTileAt` to update the wall layer during map regeneration.

* **MainScene.ts**
  - Import `getTileAt` and `putTileAt` from `phaser`
  - Update `regenerateMap` to use `getTileAt` and `putTileAt` to update the wall layer

* **MapGenerator.ts**
  - Export `generatePlayableMap` as a named export
  - Add `generatePlayableMap` method to generate a playable map with specified dimensions and wall thickness

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/abrie/nl5/issues/70?shareId=234a4ea7-4f46-4c06-9ee1-110cfe59d082).