### PR TITLE
Fix player collision with walls after map regeneration

### DIFF
--- a/src/MainScene.ts
+++ b/src/MainScene.ts
@@ -339,6 +339,7 @@ class MainScene extends Scene {
 
 		layer.tilemapLayer.setCollisionByExclusion([0]);
 
+		this.physics.world.colliders.remove(this.playerCollider);
 		this.playerCollider = this.physics.add.collider(
 			this.player,
 			this.getWallLayer(this.map),


### PR DESCRIPTION
Related to #73

Update the `regenerateMap` method in `src/MainScene.ts` to properly re-enable collision between the player and the new map.

* Add removal of the existing `playerCollider` before re-assigning it.
* Ensure the `setCollisionByExclusion` method is called on the new map layer to establish collision detection.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/abrie/nl5/issues/73?shareId=9122c889-efc1-4c38-867e-ca55e4aba578).