### PR TITLE
Use -1 for empty tiles

### DIFF
--- a/src/MainScene.ts
+++ b/src/MainScene.ts
@@ -63,7 +63,7 @@ class MainScene extends Scene {
 		}
 
 		// Enable collision for wall tiles
-		layer.setCollisionByExclusion([0]);
+		layer.setCollisionByExclusion([-1]);
 
 		return tilemap;
 	}
@@ -266,12 +266,12 @@ class MainScene extends Scene {
 
 		for (let row = 0; row < map.length; row++) {
 			for (let col = 0; col < map[row].length; col++) {
-				if (map[row][col] === 0 && Math.random() < 0.1) {
+				if (map[row][col] === -1 && Math.random() < 0.1) {
 					const lootItem = this.loot.create(
 						col * tileSize,
 						row * tileSize,
 						"loot",
-					);
+						);
 					lootItem.setOrigin(0, 0);
 				}
 			}
@@ -332,12 +332,12 @@ class MainScene extends Scene {
 			for (let col = 0; col < map[row].length; col++) {
 				const tile = layer.tilemapLayer.getTileAt(col, row);
 				if (tile) {
-					layer.tilemapLayer.putTileAt(map[row][col] === 0 ? -1 : 0, col, row);
+					layer.tilemapLayer.putTileAt(map[row][col] === -1 ? -1 : 0, col, row);
 				}
 			}
 		}
 
-		layer.tilemapLayer.setCollisionByExclusion([0]);
+		layer.tilemapLayer.setCollisionByExclusion([-1]);
 
 		this.physics.world.colliders.remove(this.playerCollider);
 		this.playerCollider = this.physics.add.collider(

--- a/src/MapGenerator.ts
+++ b/src/MapGenerator.ts
@@ -19,7 +19,7 @@ class MapGenerator {
 				) {
 					map[row][col] = 1;
 				} else {
-					map[row][col] = Math.random() < 0.2 ? 1 : 0;
+					map[row][col] = Math.random() < 0.2 ? 1 : -1;
 				}
 			}
 		}
@@ -31,9 +31,9 @@ class MapGenerator {
 				for (let col = wallThickness; col < cols - wallThickness; col++) {
 					const neighbors = this.countNeighbors(map, row, col);
 					if (map[row][col] === 1) {
-						newMap[row][col] = neighbors >= 4 ? 1 : 0;
+						newMap[row][col] = neighbors >= 4 ? 1 : -1;
 					} else {
-						newMap[row][col] = neighbors >= 5 ? 1 : 0;
+						newMap[row][col] = neighbors >= 5 ? 1 : -1;
 					}
 				}
 			}
@@ -62,7 +62,7 @@ class MapGenerator {
 	/**
 	 * Checks if the playable area in the generated map is sufficient.
 	 * This method uses Depth-First Search (DFS) to traverse the map and count the size of the playable area.
-	 * A playable area is defined as a contiguous region of empty cells (value 0).
+	 * A playable area is defined as a contiguous region of empty cells (value -1).
 	 * The method starts the DFS from the first empty cell found and counts the number of empty cells in the region.
 	 * If the size of the playable area is greater than or equal to the specified threshold, the map is considered playable.
 	 *
@@ -100,7 +100,7 @@ class MapGenerator {
 		// Start DFS from the first empty cell found
 		for (let row = 0; row < rows; row++) {
 			for (let col = 0; col < cols; col++) {
-				if (map[row][col] === 0) {
+				if (map[row][col] === -1) {
 					dfs(row, col);
 					return playableAreaSize >= 100; // Adjust the threshold as needed
 				}
@@ -116,7 +116,7 @@ class MapGenerator {
 		wallThickness: number = 0,
 	): number[][] {
 		let map: number[][] = Array.from({ length: mapHeight }, () =>
-			Array(mapWidth).fill(0),
+			Array(mapWidth).fill(-1),
 		);
 		return this.generateMap(map, wallThickness, mapWidth, mapHeight);
 	}


### PR DESCRIPTION
Related to #75

Update map generation to use -1 for empty tiles instead of 0.

* **Map Generation**: Modify `src/MapGenerator.ts` to use -1 for empty tiles in the `generateMap` method and update the `isPlayableAreaSufficient` method to check for -1 instead of 0.
* **Main Scene**: Modify `src/MainScene.ts` to use -1 for empty tiles in the `instantiateMap`, `generateLoot`, and `regenerateMap` methods.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/abrie/nl5/issues/75?shareId=95a5063c-782b-4958-8c99-f559857b5d63).